### PR TITLE
9章

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -173,6 +173,20 @@ input {
 .field_with_errors {
   @extend .has-error;
   .form-control {
-  color: $state-danger-text;  
+  color: $state-danger-text;
   }
+}
+
+.checkbox {
+  margin-top: -10px;
+  margin-bottom: 10px;
+  span {
+    margin-left: 20px;
+    font-weight: nomal;
+  }
+}
+
+#session_remember_me {
+  width: auto;
+  margin-left: 0;
 }

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,11 +3,12 @@ class SessionsController < ApplicationController
   end
 
   def create
-    user = User.find_by(email: params[:session][:email].downcase) #paramsハッシュで受け取ったemail値を小文字化して、email属性に渡してUserモデルから同じemailの値のuserを探して、user変数に代入
+    @user = User.find_by(email: params[:session][:email].downcase) #paramsハッシュで受け取ったemail値を小文字化して、email属性に渡してUserモデルから同じemailの値のuserを探して、user変数に代入
         # 上記のparams[:session]を細かく見ると → { session: { params: "foobar", email: "user@example.com"} }
-    if user && user.authenticate(params[:session][:password]) #user変数がDBに存在し（&&で判別）、尚且つparamsハッシュを受け取ったpassword値とuserのemail値が同じであればtrue
-      log_in user #session_helperのlog_inメソッドを実行し、sessionメソッドのuser_id（ブラウザに一時coolieとして保持）にidを送る
-      redirect_to user # ログインしたユーザーのユーザーページにリダイレクト
+    if @user && @user.authenticate(params[:session][:password]) #user変数がDBに存在し（&&で判別）、尚且つparamsハッシュを受け取ったpassword値とuserのemail値が同じであればtrue
+      log_in @user #session_helperのlog_inメソッドを実行し、sessionメソッドのuser_id（ブラウザに一時coolieとして保持）にidを送る
+      params[:session][:remember_me] == '1' ? remember(@user) : forget(@user)
+      redirect_to @user # ログインしたユーザーのユーザーページにリダイレクト
     else
       flash.now[:danger] = "メールアドレス/パスワードが間違えています"
       render 'new'
@@ -15,8 +16,8 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    log_out               #ログアウトする
-    redirect_to root_url  #ホームへリダイレクトする
+    log_out if logged_in?   #ユーザーが（別タブなどで開いている状態で）ログインしていたらログアウトする
+    redirect_to root_url    #ホームへリダイレクトする
   end
 
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -5,10 +5,24 @@ module SessionsHelper
     session[:user_id] = user.id # ユーザーIDをsessionのuser_idに代入（ログインIDの保持）
   end
 
-  # 現在ログイン中のユーザー（current_user）を返す（いる場合）
+  # ユーザーのセッションを永続的にする
+  def remember(user)
+    user.remember
+    cookies.permanent.signed[:user_id] = user.id
+    cookies.permanent[:remember_token] = user.remember_token
+  end
+
+  # 現在ログイン中のユーザー（current_user）を返す（いる場合）&記憶トークンcookieに対応するユーザーを返す
   def current_user
-    if session[:user_id] # ログインユーザーがいたらtrue処理
-      @current_user ||= User.find_by(id: session[:user_id]) # ログインユーザーがいればそのまま、いなければcookieのユーザーと同じidを持つユーザーをDBから探して@current_userに代入
+    if (user_id = session[:user_id])
+      @current_user ||= User.find_by(id: user_id)
+    elsif (user_id = cookies.signed[:user_id])
+      #raise  # 「raise」を置くことでわざとエラーをだす。もしテストがパスすれば、この部分がテストされていないことがわかる
+      user = User.find_by(id: user_id)
+      if user && user.authenticated?(cookies[:remember_token])
+        log_in user
+        @current_user = user
+      end
     end
   end
 
@@ -17,8 +31,16 @@ module SessionsHelper
     !current_user.nil? # current_user（ログインユーザー）がnilじゃ無いならtrue、それ以外はfalseを返す。!を先頭に付けることによって、否定演算子(not)を使い、本来ならnilならtrueの所をnilじゃないならtrueにしている。
   end
 
+  #永続的セッションを破棄する
+  def forget(user)
+    user.forget
+    cookies.delete(:user_id)
+    cookies.delete(:remember_token)
+  end
+
   # 現在のユーザーをログアウトする
   def log_out
+    forget(current_user)
     session.delete(:user_id)  # sessionのユーザーIDを削除する
     @current_user = nil       # 現在のログインユーザー（一時的なcookie）をnil（空に）する
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
 
+  attr_accessor :remember_token
+
   before_save { self.email = email.downcase } #DBに保存する前にemail属性を強制的に小文字に変換する
 
   validates :name, presence: true, length: { maximum: 50 } #nameは空は許さず、50文字以下
@@ -18,6 +20,28 @@ class User < ApplicationRecord
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
                                                    BCrypt::Engine.cost
      BCrypt::Password.create(string, cost: cost)
+   end
+
+   # ランダムなトークンを返す
+   def User.new_token
+     SecureRandom.urlsafe_base64
+   end
+
+   # 永続的セッションのためにユーザーをデータベースに記憶させる
+   def remember
+     self.remember_token = User.new_token
+     update_attribute(:remember_digest, User.digest(remember_token))
+   end
+
+   # 渡されたトークンがダイジェストと一致したらtrueを返す
+   def authenticated?(remember_token)
+     return false if remember_digest.nil?
+     BCrypt::Password.new(remember_digest).is_password?(remember_token)
+   end
+
+   # ユーザーのログイン情報を破棄する
+   def forget
+     update_attribute(:remember_digest, nil)
    end
 
 end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -11,6 +11,11 @@
       <%= f.label :password, "パスワード" %>
       <%= f.password_field :password, class: 'form-control' %>
 
+      <%= f.label :remember_me, class: "checkbox inline" do %>
+        <%= f.check_box :remember_me %>
+        <span>次回から自動でログインする</span>
+      <% end %>
+
       <%= f.submit "Log in", class: "btn btn-primary" %>
     <% end %>
 

--- a/db/migrate/20190531065720_add_remember_digest_to_users.rb
+++ b/db/migrate/20190531065720_add_remember_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddRememberDigestToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :remember_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_30_000118) do
+ActiveRecord::Schema.define(version: 2019_05_31_065720) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2019_05_30_000118) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "password_digest"
+    t.string "remember_digest"
   end
 
 end

--- a/test/helpers/sessions_helper_test.rb
+++ b/test/helpers/sessions_helper_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class SessionsHelperTest < ActionView::TestCase
+
+  def setup
+    @user = users(:michael)
+    remember(@user)
+  end
+
+  test "current_user returns right user when session is nil" do
+    assert_equal @user, current_user # assert_equalの引数は「期待する値」「実際の値」の順番で記述
+    assert is_logged_in?
+  end
+
+  test "current_user returns nil when remember digest is wrong" do
+    @user.update_attribute(:remember_digest, User.digest(User.new_token))
+    assert_nil current_user
+  end
+
+end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -44,10 +44,26 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     delete logout_path
     assert_not is_logged_in?
     assert_redirected_to root_url
+    # 2番目のウィンドウ（cromeやfirefoxなど）でログアウトをクリックするユーザーをシミュレートする
+    delete logout_path
     follow_redirect!
     assert_select "a[href=?]", login_path
     assert_select "a[href=?]", logout_path,      count: 0
     assert_select "a[href=?]", user_path(@user), count: 0
+  end
+
+  test "login with remembering" do
+    log_in_as(@user, remember_me: '1')
+    assert_equal cookies['remember_token'], assigns(:user).remember_token
+  end
+
+  test "login without remembering" do
+    # クッキーを保存してログイン
+    log_in_as(@user, remember_me: '1')
+    delete logout_path
+    # クッキーを削除してログイン
+    log_in_as(@user, remember_me: '0')
+    assert_empty cookies['remember_token']
   end
 
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -63,5 +63,9 @@ class UserTest < ActiveSupport::TestCase
     assert_not @user.valid?
   end
 
+  test "authenticated? should return false for a user with nil digest" do
+    assert_not @user.authenticated?('')
+  end
+
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,5 +12,19 @@ class ActiveSupport::TestCase
     !session[:user_id].nil?
   end
 
-  # Add more helper methods to be used by all tests here...
+  # テストユーザーとしてログインする
+  def log_in_as(user)
+    session[:user_id] = user.id
+  end
+end
+
+class ActionDispatch::IntegrationTest
+
+  #テストユーザーとしてログインする
+  # テストユーザーとしてログインする
+  def log_in_as(user, password: 'password', remember_me: '1')
+    post login_path, params: { session: { email: user.email,
+                                          password: password,
+                                          remember_me: remember_me } }
+  end
 end


### PR DESCRIPTION
・ログインの保持
・ログインを保持し続けないように、ユーザーを忘れる
・二つのタブで開いて、片方でログアウトした後に、もう片方をログアウトするとエラーになるのを解消
・ユーザーがFirefoxとChromeでログインしていたとして、Firefoxでログアウトする。そして、Chromeではロウアウトせずに、ブラウザを終了させ、再度開くとエラーとなってしまうのを解消
・remember meチェックボックスの導入
