### PR TITLE
10-2まで

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,7 +8,7 @@ class SessionsController < ApplicationController
     if @user && @user.authenticate(params[:session][:password]) #user変数がDBに存在し（&&で判別）、尚且つparamsハッシュを受け取ったpassword値とuserのemail値が同じであればtrue
       log_in @user #session_helperのlog_inメソッドを実行し、sessionメソッドのuser_id（ブラウザに一時coolieとして保持）にidを送る
       params[:session][:remember_me] == '1' ? remember(@user) : forget(@user)
-      redirect_to @user # ログインしたユーザーのユーザーページにリダイレクト
+      redirect_back_or @user 
     else
       flash.now[:danger] = "メールアドレス/パスワードが間違えています"
       render 'new'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,7 @@
 class UsersController < ApplicationController
+  before_action :logged_in_user, only: [:edit, :update]
+  before_action :correct_user, only: [:edit, :update]
+
   def new
     @user = User.new
   end
@@ -18,8 +21,46 @@ class UsersController < ApplicationController
     end
   end
 
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def update
+    @user = User.find(params[:id])
+    if @user.update_attributes(user_params)
+      flash[:success] = "Profile updated"
+      redirect_to @user
+    else
+      render 'edit'
+    end
+  end
+
   def user_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation)
   end
+
+  private
+
+    def user_params
+      params.require(:user).permit(:name, :email, :password,
+                                  :password_confirmation)
+    end
+
+    # beforeアクション
+
+    # ログイン済みユーザーか確認
+    def logged_in_user
+      unless logged_in?
+        store_location
+        flash[:danger] = "ログインしてください"
+        redirect_to login_url
+      end
+    end
+
+    # 正しいユーザーかどうか確認
+    def correct_user
+      @user = User.find(params[:id])
+      redirect_to(root_url) unless current_user?(@user)
+    end
 
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -12,6 +12,11 @@ module SessionsHelper
     cookies.permanent[:remember_token] = user.remember_token
   end
 
+  # 渡されたユーザーがログイン済みユーザーであればtrueを返す
+  def current_user?(user)
+    user == current_user
+  end
+
   # 現在ログイン中のユーザー（current_user）を返す（いる場合）&記憶トークンcookieに対応するユーザーを返す
   def current_user
     if (user_id = session[:user_id])
@@ -43,6 +48,17 @@ module SessionsHelper
     forget(current_user)
     session.delete(:user_id)  # sessionのユーザーIDを削除する
     @current_user = nil       # 現在のログインユーザー（一時的なcookie）をnil（空に）する
+  end
+
+  # 記憶したURL（もしくはデフォルト値）にリダイレクト
+  def redirect_back_or(default)
+    redirect_to(session[:forwarding_url] || default)
+    session.delete(:forwarding_url)
+  end
+
+  # アクセスしよとしたURLを覚えておく
+  def store_location
+    session[:forwarding_url] = request.original_url if request.get?
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
               uniqueness: { case_sensitive: false } #「uniqueness」は対象のDB内で一意である必要であるフィールドに対して指定。「case_sensigtive」は「false」を指定することで、大文字小文字の差を無視する。
 
   has_secure_password #セキュアなパスワードの実行
-  validates :password, presence: true, length: { minimum: 6 }
+  validates :password, presence: true, length: { minimum: 6 }, allow_nil: true
 
   # fixture用に、password_digestの文字列をハッシュ化して、ハッシュ値として返す
   def User.digest(string)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,7 +13,7 @@
             </a>
             <ul class="dropdown-menu">
               <li><%= link_to "プロフィール", current_user %></li>  <!-- current_userのプロフィールページ -->
-              <li><%= link_to "環境設定", "#" %></li>
+              <li><%= link_to "環境設定", edit_user_path(current_user) %></li>
               <li class="divider"></li>
               <li>
                 <%= link_to "ログアウト", logout_path, method: :delete %>  <!-- ログアウト -->

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_for(@user, url: yield(:url)) do |f| %>
+  <%= render 'shared/error_messages', object: @user %>
+
+  <%= f.label :name, "名前" %>
+  <%= f.text_field :name, class: 'form-control' %>
+
+  <%= f.label :email, "メールアドレス" %>
+  <%= f.email_field :email, class: 'form-control' %>
+
+  <%= f.label :password, "パスワード" %>
+  <%= f.password_field :password, class: 'form-control' %>
+
+  <%= f.label :password_confirmation, "パスワード（確認）" %>
+  <%= f.password_field :password_confirmation, class: 'form-control' %>
+
+  <%= f.submit yield(:button_text), class: "btn btn-primary" %>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,14 @@
+<% provide(:title, "Edit user") %>
+<% provide(:url, user_path) %>
+<% provide(:button_text, '変更する') %>
+<h1>Update your profile</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= render 'form' %>
+    <div class="gravatar_edit">
+      <%= gravatar_for @user %>
+      <a href="http://gravatar.com/emails" target="_blank" rel="noopener">変更する</a>
+    </div>
+  </div>
+</div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,26 +1,9 @@
-<%= provide(:title, 'Sign up') %>
+<% provide(:title, 'Sign up') %>
+<% provide(:url, signup_path) %>
+<% provide(:button_text, 'アカウントを作成する') %>
 <h1>Sign up</h1>
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
-    <!-- doキーワードは、「form_for」が一つの変数をもつブロックを取ることを表す。「|f|」この変数は"form"の"f" -->
-    <%= form_for(@user, url: signup_path) do |f| %>
-      <%= render 'shared/error_messages' %>
-
-      <%= f.label :name, "名前" %>
-      <%= f.text_field :name, class: 'form-control' %>
-
-      <%= f.label :email, "メールアドレス" %>
-      <%= f.email_field :email, class: 'form-control' %>
-
-      <%= f.label :password, "パスワード" %>
-      <%= f.password_field :password, class: 'form-control' %>
-
-      <%= f.label :password_confirmation, "パスワード（確認）" %>
-      <%= f.password_field :password_confirmation, class: 'form-control' %>
-
-      <%= f.submit "Create my account", class: "btn btn-primary" %>
-
-    <% end %>
-
+    <%= render 'form' %>
   </div>
 </div>

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,9 +1,27 @@
 require 'test_helper'
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @user = users(:michael)
+    @other_user = users(:archer)
+  end
+
   test "should get new" do
     get signup_path
     assert_response :success
   end
 
+  test "should redirect edit when not logged in" do
+    get edit_user_path(@user)
+    assert_not flash.empty?
+    assert_redirected_to login_url
+  end
+
+  test "should redirect update when not logged in" do
+    patch user_path(@user), params: { user: { name: @user.name,
+                                              email: @user.email } }
+    assert_not flash.empty?
+    assert_redirected_to login_url
+  end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -2,3 +2,8 @@ michael:
   name: Michael Example
   email: michael@example.com
   password_digest: <%= User.digest('password') %>
+
+archer:
+  name: Sterling Archer
+  email: duchess@example.gov
+  password_digest: <%= User.digest('password') %>

--- a/test/integration/users_edit_test.rb
+++ b/test/integration/users_edit_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class UsersEditTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @user = users(:michael)
+  end
+
+  test "unsuccessful edit" do
+    log_in_as(@user)
+    get edit_user_path(@user)
+    assert_template 'users/edit'
+    patch user_path(@user), params: { user: { name:  "",
+                                              email: "foo@invalid",
+                                              password:              "foo",
+                                              password_confirmation: "bar" } }
+
+    assert_template 'users/edit'
+  end
+
+  test "successful edit with friendly forwarding" do
+    get edit_user_path(@user)
+    assert_equal session[:forwarding_url], edit_user_url(@user) # 演習10.2.3で追加
+    log_in_as(@user)
+    assert_nil session[:forwarding_url] # 演習10.2.3で追加
+    # assert_redirected_to edit_user_url(@user) # 演習10.2.3で非表示
+    name  = "Foo Bar"
+    email = "foo@bar.com"
+    patch user_path(@user), params: { user: { name:  name,
+                                              email: email,
+                                              password:              "",
+                                              password_confirmation: "" } }
+    assert_not flash.empty?
+    assert_redirected_to @user
+    @user.reload
+    assert_equal name,  @user.name
+    assert_equal email, @user.email
+  end
+end


### PR DESCRIPTION
UsersモデルのRESTfulで未実装だった、「edit」「update」を作成。
「/users/:id/edit」を開くと誰でも（ログインしていないユーザーでも）、該当ユーザーじゃないのに編集ができてしまうバグを修正。